### PR TITLE
Refactor parse method for improved directory path inference

### DIFF
--- a/lib/dirfy/parser.rb
+++ b/lib/dirfy/parser.rb
@@ -44,11 +44,12 @@ module Dirfy
       items.each_with_index.map do |path, i|
         is_dir = directory?(names[i], i, depths)
         is_dir ? (path.end_with?("/") ? path : "#{path}/") : path
-      private
-  
+      end
+
+    private
+
       def directory?(name, index, depths)
         name.end_with?("/") || (index < depths.size - 1 && depths[index + 1] > depths[index])
       end
-    end
   end
 end

--- a/lib/dirfy/parser.rb
+++ b/lib/dirfy/parser.rb
@@ -13,6 +13,8 @@ module Dirfy
     def parse(lines)
       stack = []
       items = []
+      depths = []
+      names = []
 
       lines.each do |raw|
         line = raw.rstrip
@@ -31,14 +33,18 @@ module Dirfy
 
         stack[depth] = name
         stack = stack[0..depth]
-
-        # build full path
+        # build full path (no trailing slash yet)
         path = stack.map { |c| c.chomp("/") }.join("/")
-        path << "/" if name.end_with?("/")
+        depths << depth
+        names << name
         items << path
       end
 
-      items
+      # Second pass: infer directories by depth
+      items.each_with_index.map do |path, i|
+        is_dir = names[i].end_with?("/") || (i < depths.size - 1 && depths[i+1] > depths[i])
+        is_dir ? (path.end_with?("/") ? path : "#{path}/") : path
+      end
     end
   end
 end

--- a/lib/dirfy/parser.rb
+++ b/lib/dirfy/parser.rb
@@ -42,8 +42,12 @@ module Dirfy
 
       # Second pass: infer directories by depth
       items.each_with_index.map do |path, i|
-        is_dir = names[i].end_with?("/") || (i < depths.size - 1 && depths[i+1] > depths[i])
+        is_dir = directory?(names[i], i, depths)
         is_dir ? (path.end_with?("/") ? path : "#{path}/") : path
+      private
+  
+      def directory?(name, index, depths)
+        name.end_with?("/") || (index < depths.size - 1 && depths[index + 1] > depths[index])
       end
     end
   end

--- a/lib/dirfy/parser.rb
+++ b/lib/dirfy/parser.rb
@@ -45,11 +45,12 @@ module Dirfy
         is_dir = directory?(names[i], i, depths)
         is_dir ? (path.end_with?("/") ? path : "#{path}/") : path
       end
+    end
 
-    private
+  private
 
-      def directory?(name, index, depths)
-        name.end_with?("/") || (index < depths.size - 1 && depths[index + 1] > depths[index])
-      end
+    def directory?(name, index, depths)
+      name.end_with?("/") || (index < depths.size - 1 && depths[index + 1] > depths[index])
+    end
   end
 end


### PR DESCRIPTION
Enhance the parse method to better infer directory paths and improve clarity by moving directory logic to a private method.